### PR TITLE
fix type error at README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ import { Client } from 'hatena-bookmark-api';
 const client = new Client({
   consumerKey: 'consumerKey',
   consumerSecret: 'consumerSecret',
-  token: 'token',
-  tokenSecret: 'tokenSecret'
+  accessToken: 'accessToken',
+  accessTokenSecret: 'accessTokenSecret'
 });
 
 // GET /1/my/bookmark


### PR DESCRIPTION
Thanks to making useful library :)

This PR tries to fix type error at usage.

From below code, Credentials interface seems must have accessToken & accessTokenSecret.

https://github.com/bouzuya/node-hatena-bookmark-api/blob/088c27153e0092ff700c0c87d5ef901a31392bd1/src/client.ts#L51-L56